### PR TITLE
fix: sha for Skaffold v2.4.1 after binary update

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-﻿$checksum = "3b4bf09c44ff207e1231e19457de82eaadf1805d6db9aa22d2a8831866de3ece"
+﻿$checksum = "9b99410dbf3517fb18fdb7476bf49e8d91582fe15286f0ac996b04563fe26ae5"
 $ErrorActionPreference = 'Stop';
 $packageName = 'skaffold'
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition


### PR DESCRIPTION
Wrong windows binary was attached with the release of Skaffold v2.4.1. Now the binary and the sha code are updated in the [release](https://github.com/GoogleContainerTools/skaffold/releases/tag/v2.4.1). This PR is to update the Chocolatey sha accordingly.